### PR TITLE
Add build instructions and spec placeholder

### DIFF
--- a/OuroLang_Spec_2_0.md
+++ b/OuroLang_Spec_2_0.md
@@ -1,0 +1,1 @@
+# OuroLang Language Specification 2.0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Oura
+
+This repository contains experimental implementations of the OuroLang programming language.
+
+## Building
+
+A simple C++ interpreter is provided in `ouro_lang.cc`. You can build it using g++:
+
+```bash
+g++ -std=c++23 ouro_lang.cc -o ouro_lang
+```
+
+Then run the REPL:
+
+```bash
+./ouro_lang
+```
+
+A Zig build script is also included (`build.zig`) for environments with the Zig compiler installed.


### PR DESCRIPTION
## Summary
- expanded README with basic build instructions for the C++ interpreter
- added placeholder for `OuroLang Language Specification 2.0`

## Testing
- `g++ -std=c++23 ouro_lang.cc -o ouro_lang`

------
https://chatgpt.com/codex/tasks/task_e_6843e4a7ccf48331a7a5c0cb8c42d63a