### PR TITLE
Add compiler project scaffold with CI, docs, and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y build-essential cmake clang clang-format clang-tidy git python3-pip \
+                       libssl-dev ninja-build && \
+    pip3 install conan
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "OuroLang Dev",
+  "build": { "dockerfile": "Dockerfile" },
+  "workspaceFolder": "/workspace",
+  "extensions": [
+    "ms-vscode.cpptools",
+    "ms-vscode.cmake-tools",
+    "llvm-vs-code-extensions.vscode-clangd"
+  ],
+  "settings": {
+    "C_Cpp.intelliSenseEngine": "Default",
+    "cmake.sourceDirectory": "${workspaceFolder}"
+  },
+  "forwardPorts": [3000]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          sudo apt-get update && sudo apt-get install -y clang-format
+          find src include tests -iname '*.cpp*' | xargs clang-format --dry-run --Werror
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          sudo apt-get update && sudo apt-get install -y clang-tidy
+          find src include -iname '*.cpp*' | xargs clang-tidy -quiet
+
+  build-test:
+    runs-on: ubuntu-latest
+    services:
+      docker:
+        image: my_compiler/ci:latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          mkdir build && cd build
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain.cmake ..
+          cmake --build . -- -j$(nproc)
+          ctest --output-on-failure
+
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          # build AFL++ harness
+          mkdir build && cd build
+          cmake -DENABLE_FUZZ=ON .. 
+          make fuzz_lexer
+          ./fuzz_lexer -i ../fuzz/corpus -o ./findings -t 1000

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.23)
+project(OuroLang LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+
+add_subdirectory(src)
+add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Then run the REPL:
 ```
 
 A Zig build script is also included (`build.zig`) for environments with the Zig compiler installed.
+
+## Repository Structure
+
+The project now includes a CMake-based build system, tests, container setup, and documentation. Run `cmake` in a `build` directory to configure and build the modules in `src/`.

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Additional toolchain configuration can go here

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,3 @@
+# Architecture
+
+Overview of the OuroLang compiler architecture.

--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -1,0 +1,3 @@
+# Build System
+
+Instructions for building the project using CMake and Conan.

--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Guidelines for contributing to OuroLang.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,3 @@
+# Module Overview
+
+Documentation for each C++ module in the compiler.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,3 @@
+# Testing
+
+How to run tests and fuzzing harnesses.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(ourlang STATIC
+    placeholder.cpp
+)
+
+set_target_properties(ourlang PROPERTIES CXX_STANDARD 23 CXX_STANDARD_REQUIRED YES)

--- a/src/codegen.cppm
+++ b/src/codegen.cppm
@@ -1,0 +1,3 @@
+export module codegen;
+
+export void emit_code();

--- a/src/core.cppm
+++ b/src/core.cppm
@@ -1,0 +1,3 @@
+export module core;
+
+export int add(int a, int b);

--- a/src/core.impl.cpp
+++ b/src/core.impl.cpp
@@ -1,0 +1,3 @@
+module core;
+
+export int add(int a, int b) { return a + b; }

--- a/src/ir.cppm
+++ b/src/ir.cppm
@@ -1,0 +1,3 @@
+export module ir;
+
+export void build_ir();

--- a/src/ir/partitions/passes.cppm
+++ b/src/ir/partitions/passes.cppm
@@ -1,0 +1,3 @@
+export module ir:passes;
+
+export void run_passes();

--- a/src/ir/partitions/transforms.cppm
+++ b/src/ir/partitions/transforms.cppm
@@ -1,0 +1,3 @@
+export module ir:transforms;
+
+export void apply_transforms();

--- a/src/parser.cppm
+++ b/src/parser.cppm
@@ -1,0 +1,3 @@
+export module parser;
+
+export int parse(const char* input);

--- a/src/parser.impl.cpp
+++ b/src/parser.impl.cpp
@@ -1,0 +1,3 @@
+module parser;
+
+export int parse(const char* input) { return *input; }

--- a/src/placeholder.cpp
+++ b/src/placeholder.cpp
@@ -1,0 +1,2 @@
+#include <iostream>
+int add(int a,int b){return a+b;}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+enable_testing()
+
+add_executable(lexer_tests lexer_tests.cpp)
+target_link_libraries(lexer_tests PRIVATE ourlang)
+add_test(NAME LexerTests COMMAND lexer_tests)
+
+add_executable(codegen_tests codegen_tests.cpp)
+target_link_libraries(codegen_tests PRIVATE ourlang)
+add_test(NAME CodegenTests COMMAND codegen_tests)

--- a/tests/codegen_tests.cpp
+++ b/tests/codegen_tests.cpp
@@ -1,0 +1,5 @@
+#include <cassert>
+int main() {
+    assert(true);
+    return 0;
+}

--- a/tests/lexer_tests.cpp
+++ b/tests/lexer_tests.cpp
@@ -1,0 +1,5 @@
+#include <cassert>
+int main() {
+    assert(1 == 1);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add CI workflow with formatting, analysis, build, and fuzz jobs
- set up devcontainer for reproducible builds
- provide CMake-based project skeleton with modules and tests
- add basic documentation files and update README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6843eae852bc833186c3b8bcccc91cbf