### PR TITLE
Add basic Zig engine skeleton

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -118,4 +118,12 @@ pub fn build(b: *std.Build) void {
     });
     zig_nvim.linkLibC();
     b.installArtifact(zig_nvim);
+    const zig_engine = b.addExecutable(.{
+        .name = "zig_engine",
+        .target = target,
+        .optimize = optimize,
+        .root_source_file = .{ .path = "src/engine/app.zig" },
+    });
+    zig_engine.linkLibC();
+    b.installArtifact(zig_engine);
 }

--- a/src/engine/app.zig
+++ b/src/engine/app.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const platform = @import("platform.zig");
+const graphics = @import("graphics.zig");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer std.debug.assert(gpa.deinit() == .ok);
+    const allocator = gpa.allocator();
+
+    var plat = try platform.create(allocator);
+    defer plat.deinit();
+
+    var gfx = try graphics.create(allocator, .{});
+    defer gfx.deinit();
+
+    var window = try plat.createWindow("Zig Engine", 1280, 720);
+    defer window.destroy();
+
+    while (!window.shouldClose()) {
+        plat.pollEvents();
+        gfx.beginFrame();
+        // TODO: issue rendering commands
+        gfx.endFrame();
+    }
+}

--- a/src/engine/graphics.zig
+++ b/src/engine/graphics.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub const BackendType = enum { vulkan, metal, directx12, opengl };
+
+pub const Graphics = struct {
+    allocator: std.mem.Allocator,
+    backend: BackendType,
+
+    pub fn beginFrame(self: *Graphics) void {
+        _ = self;
+    }
+
+    pub fn endFrame(self: *Graphics) void {
+        _ = self;
+    }
+
+    pub fn deinit(self: *Graphics) void {
+        self.allocator.destroy(self);
+    }
+};
+
+pub fn create(allocator: std.mem.Allocator, comptime config: anytype) !*Graphics {
+    const backend: BackendType = if (@hasField(@TypeOf(config), "backend"))
+        config.backend
+    else
+        switch (@import("builtin").target.os.tag) {
+            .macos => .metal,
+            .windows => .directx12,
+            else => .vulkan,
+        };
+    const g = try allocator.create(Graphics);
+    g.* = .{ .allocator = allocator, .backend = backend };
+    return g;
+}

--- a/src/engine/platform.zig
+++ b/src/engine/platform.zig
@@ -1,0 +1,45 @@
+const std = @import("std");
+
+pub const Window = struct {
+    should_close: bool = false,
+    pub fn destroy(self: *Window) void {
+        _ = self;
+        // Platform specific cleanup
+    }
+    pub fn shouldClose(self: *Window) bool {
+        return self.should_close;
+    }
+};
+
+pub const Platform = struct {
+    allocator: std.mem.Allocator,
+    state: *anyopaque,
+    create_window: fn (*anyopaque, []const u8, u32, u32) anyerror!*Window,
+    poll_events: fn (*anyopaque) void,
+    deinit_fn: fn (*anyopaque) void,
+
+    pub fn createWindow(self: *Platform, title: []const u8, width: u32, height: u32) !*Window {
+        return self.create_window(self.state, title, width, height);
+    }
+
+    pub fn pollEvents(self: *Platform) void {
+        self.poll_events(self.state);
+    }
+
+    pub fn deinit(self: *Platform) void {
+        self.deinit_fn(self.state);
+    }
+};
+
+pub fn create(allocator: std.mem.Allocator) !Platform {
+    const builtin = @import("builtin");
+    switch (builtin.target.os.tag) {
+        .windows => return windows.init(allocator),
+        .macos => return macos.init(allocator),
+        else => return linux.init(allocator),
+    }
+}
+
+const windows = @import("platform/windows.zig");
+const macos = @import("platform/macos.zig");
+const linux = @import("platform/linux.zig");

--- a/src/engine/platform/linux.zig
+++ b/src/engine/platform/linux.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const platform = @import("../platform.zig");
+
+pub const PlatformImpl = struct {
+    allocator: std.mem.Allocator,
+};
+
+pub fn init(allocator: std.mem.Allocator) !platform.Platform {
+    var impl = try allocator.create(PlatformImpl);
+    impl.* = .{ .allocator = allocator };
+    return platform.Platform{
+        .allocator = allocator,
+        .state = impl,
+        .create_window = createWindow,
+        .poll_events = pollEvents,
+        .deinit_fn = deinit,
+    };
+}
+
+fn createWindow(ptr: *anyopaque, title: []const u8, width: u32, height: u32) !*platform.Window {
+    _ = title; _ = width; _ = height;
+    const self = @ptrCast(*PlatformImpl, ptr);
+    return self.allocator.create(platform.Window);
+}
+
+fn pollEvents(ptr: *anyopaque) void {
+    _ = ptr;
+}
+
+fn deinit(ptr: *anyopaque) void {
+    const self = @ptrCast(*PlatformImpl, ptr);
+    self.allocator.destroy(self);
+}

--- a/src/engine/platform/macos.zig
+++ b/src/engine/platform/macos.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const platform = @import("../platform.zig");
+
+pub const PlatformImpl = struct {
+    allocator: std.mem.Allocator,
+};
+
+pub fn init(allocator: std.mem.Allocator) !platform.Platform {
+    var impl = try allocator.create(PlatformImpl);
+    impl.* = .{ .allocator = allocator };
+    return platform.Platform{
+        .allocator = allocator,
+        .state = impl,
+        .create_window = createWindow,
+        .poll_events = pollEvents,
+        .deinit_fn = deinit,
+    };
+}
+
+fn createWindow(ptr: *anyopaque, title: []const u8, width: u32, height: u32) !*platform.Window {
+    _ = title; _ = width; _ = height;
+    const self = @ptrCast(*PlatformImpl, ptr);
+    return self.allocator.create(platform.Window);
+}
+
+fn pollEvents(ptr: *anyopaque) void {
+    _ = ptr;
+}
+
+fn deinit(ptr: *anyopaque) void {
+    const self = @ptrCast(*PlatformImpl, ptr);
+    self.allocator.destroy(self);
+}

--- a/src/engine/platform/windows.zig
+++ b/src/engine/platform/windows.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const platform = @import("../platform.zig");
+
+pub const PlatformImpl = struct {
+    allocator: std.mem.Allocator,
+};
+
+pub fn init(allocator: std.mem.Allocator) !platform.Platform {
+    var impl = try allocator.create(PlatformImpl);
+    impl.* = .{ .allocator = allocator };
+    return platform.Platform{
+        .allocator = allocator,
+        .state = impl,
+        .create_window = createWindow,
+        .poll_events = pollEvents,
+        .deinit_fn = deinit,
+    };
+}
+
+fn createWindow(ptr: *anyopaque, title: []const u8, width: u32, height: u32) !*platform.Window {
+    _ = title; _ = width; _ = height;
+    const self = @ptrCast(*PlatformImpl, ptr);
+    return self.allocator.create(platform.Window);
+}
+
+fn pollEvents(ptr: *anyopaque) void {
+    _ = ptr;
+    // Stub event polling
+}
+
+fn deinit(ptr: *anyopaque) void {
+    const self = @ptrCast(*PlatformImpl, ptr);
+    self.allocator.destroy(self);
+}


### PR DESCRIPTION
## Summary
- create a small cross‑platform engine skeleton in Zig
- add Windows, macOS, and Linux platform stubs
- add a simple graphics backend abstraction
- add a new `zig_engine` executable to the build script

## Testing
- `apt-get update`
- `apt-get install -y zig` *(failed: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_684432ac9f5c8331bedcf8648c6c27da