### PR TITLE
Update to C23 and link LLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then run the REPL:
 ./ouro_lang
 ```
 
-A Zig build script is also included (`build.zig`) for environments with the Zig compiler installed.  It mirrors the basic CMake configuration and exposes tasks for running the module example and its unit tests.
+A Zig build script is also included (`build.zig`) for environments with the Zig compiler installed.  It now compiles the C portions of the project using the C23 standard and links against LLVM in addition to `libc`. The script mirrors the basic CMake configuration and exposes tasks for running the module example and its unit tests.
 
 ## Repository Structure
 

--- a/build.zig
+++ b/build.zig
@@ -12,8 +12,9 @@ pub fn build(b: *std.Build) void {
     dummy.linkLibC();
     dummy.addCSourceFiles(.{
         .files = &[_][]const u8{"dummy.c"},
-        .flags = &[_][]const u8{"-std=c99"},
+        .flags = &[_][]const u8{"-std=c23"},
     });
+    dummy.linkSystemLibrary("llvm");
     b.installArtifact(dummy);
 
     const ourolang = b.addExecutable(.{
@@ -29,6 +30,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &[_][]const u8{"-std=c++23"},
     });
+    ourolang.linkSystemLibrary("llvm");
     b.installArtifact(ourolang);
 
     const ourolang_cpp = b.addExecutable(.{
@@ -42,6 +44,7 @@ pub fn build(b: *std.Build) void {
         .files = &[_][]const u8{"OuroLang_cpp/main.cc"},
         .flags = &[_][]const u8{"-std=c++23"},
     });
+    ourolang_cpp.linkSystemLibrary("llvm");
     b.installArtifact(ourolang_cpp);
 
     const ouroboros = b.addExecutable(.{
@@ -59,8 +62,9 @@ pub fn build(b: *std.Build) void {
             "Ouroboros/Ouroboros_Compiler/src/ouroboros/token.c",
             "Ouroboros/Ouroboros_Compiler/src/ouroboros/codegen.c",
         },
-        .flags = &[_][]const u8{"-std=c11"},
+        .flags = &[_][]const u8{"-std=c23"},
     });
+    ouroboros.linkSystemLibrary("llvm");
     ouroboros.addIncludePath(b.path("Ouroboros/Ouroboros_Compiler/include"));
     b.installArtifact(ouroboros);
 
@@ -69,6 +73,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    ouro_mod.linkLibC();
     ouro_mod.linkLibCpp();
     ouro_mod.addCSourceFiles(.{
         .files = &[_][]const u8{
@@ -85,6 +90,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &[_][]const u8{ "-std=c++23", "-fmodules-ts" },
     });
+    ouro_mod.linkSystemLibrary("llvm");
     b.installArtifact(ouro_mod);
 
     const ouro_mod_run = b.addRunArtifact(ouro_mod);
@@ -95,6 +101,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    mod_tests.linkLibC();
     mod_tests.linkLibCpp();
     mod_tests.addCSourceFiles(.{
         .files = &[_][]const u8{
@@ -111,6 +118,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &[_][]const u8{ "-std=c++23", "-fmodules-ts" },
     });
+    mod_tests.linkSystemLibrary("llvm");
     const test_cmd = b.addRunArtifact(mod_tests);
     b.step("mod-test", "Run module tests").dependOn(&test_cmd.step);
 
@@ -121,6 +129,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("zig_nvim/src/main.zig"),
     });
     zig_nvim.linkLibC();
+    zig_nvim.linkSystemLibrary("llvm");
     b.installArtifact(zig_nvim);
     const zig_engine = b.addExecutable(.{
         .name = "zig_engine",
@@ -129,6 +138,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/engine/app.zig"),
     });
     zig_engine.linkLibC();
+    zig_engine.linkSystemLibrary("llvm");
     b.installArtifact(zig_engine);
 
     // convenience step to build all artifacts

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,6 +1,6 @@
 #include "ourolang/repl.h"
 
 int main() {
-    ouro::repl();
-    return 0;
+  ouro::repl();
+  return 0;
 }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1,3 +1,3 @@
 export module parser;
 
-export int parse(const char* input);
+export int parse(const char *input);

--- a/src/parser.impl.cc
+++ b/src/parser.impl.cc
@@ -1,3 +1,3 @@
 module parser;
 
-export int parse(const char* input) { return *input; }
+export int parse(const char *input) { return *input; }

--- a/src/repl_binding.cc
+++ b/src/repl_binding.cc
@@ -1,5 +1,3 @@
 #include "ourolang/repl.h"
 
-void ouro_repl() {
-    ouro::repl();
-}
+void ouro_repl() { ouro::repl(); }

--- a/tests/codegen_tests.cc
+++ b/tests/codegen_tests.cc
@@ -1,5 +1,5 @@
 #include <cassert>
 int main() {
-    assert(true);
-    return 0;
+  assert(true);
+  return 0;
 }

--- a/tests/lexer_tests.cc
+++ b/tests/lexer_tests.cc
@@ -1,5 +1,5 @@
 #include <cassert>
 int main() {
-    assert(1 == 1);
-    return 0;
+  assert(1 == 1);
+  return 0;
 }


### PR DESCRIPTION
## Summary
- build C code with `-std=c23`
- link LLVM and libc from the zig build
- document LLVM and C23 usage

## Testing
- `clang-format` on all C++ sources
- `clang-tidy` *(fails: Could not auto-detect compilation database)*
- `cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain.cmake ..`
- `cmake --build . -- -j$(nproc)`
- `ctest --output-on-failure`
- `zig build mod-test` *(fails: unsupported Zig version)*
- `cmake -DENABLE_FUZZ=ON ..` *(fails: No rule to make target `fuzz_lexer`)*


------
https://chatgpt.com/codex/tasks/task_e_684b05297c9883318ddb61b152e0b595