### PR TITLE
Add Zig installer and integrate into container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,11 @@ FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y build-essential cmake clang clang-format clang-tidy git python3-pip \
-                       libssl-dev ninja-build && \
-    pip3 install conan
+                       libssl-dev ninja-build curl && \
+    pip3 install conan && \
+    curl -L https://ziglang.org/builds/zig-linux-x86_64-0.14.1.tar.xz \
+      | tar -xJ && \
+    mv zig-linux-x86_64-0.14.1 /opt/zig && \
+    ln -s /opt/zig/zig /usr/local/bin/zig
 
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then run the REPL:
 ./ouro_lang
 ```
 
-A Zig build script is also included (`build.zig`) for environments with the Zig compiler installed.  It now compiles the C portions of the project using the C23 standard and links against LLVM in addition to `libc`. The script mirrors the basic CMake configuration and exposes tasks for running the module example and its unit tests.
+A Zig build script is also included (`build.zig`) for environments with the Zig compiler installed. It now compiles the C portions of the project using the C23 standard and links against LLVM in addition to `libc`. The script mirrors the basic CMake configuration and exposes tasks for running the module example and its unit tests. If Zig is not available, run `scripts/install_zig.sh` to download version `0.14.1` locally.
 
 ## Repository Structure
 

--- a/scripts/install_zig.sh
+++ b/scripts/install_zig.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ZIG_VERSION="0.14.1"
+ZIG_DIR="zig-x86_64-linux-${ZIG_VERSION}"
+ARCHIVE="zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+DOWNLOAD_URL="https://ziglang.org/builds/${ARCHIVE}"
+
+if command -v zig >/dev/null 2>&1; then
+    INSTALLED=$(zig version)
+    if [ "$INSTALLED" = "$ZIG_VERSION" ]; then
+        echo "Zig ${ZIG_VERSION} already installed"
+        exit 0
+    fi
+fi
+
+rm -f "$ARCHIVE"
+
+if [ ! -d "$ZIG_DIR" ]; then
+    echo "Downloading Zig ${ZIG_VERSION}..."
+    curl -L -o "$ARCHIVE" "$DOWNLOAD_URL"
+    mkdir -p "$ZIG_DIR"
+    tar -xf "$ARCHIVE" -C "$ZIG_DIR" --strip-components=1
+fi
+
+cat <<SH > zig
+#!/usr/bin/env bash
+"$(pwd)/${ZIG_DIR}/zig" "$@"
+SH
+chmod +x zig
+
+echo "Zig ${ZIG_VERSION} installed in $(pwd)/${ZIG_DIR}"


### PR DESCRIPTION
## Summary
- add script to install Zig 0.14.1 locally
- install Zig in the development container
- mention installer in README

## Testing
- `bash scripts/install_zig.sh` *(fails: tar: This does not look like a tar archive)*

------
https://chatgpt.com/codex/tasks/task_e_684c0c258994833195fe151042f5713b