### PR TITLE
Add Ouroboros vs Swift comparison doc

### DIFF
--- a/docs/swift_comparison.md
+++ b/docs/swift_comparison.md
@@ -1,0 +1,26 @@
+# Ouroboros vs Swift 6.2
+
+The document provides a high-level comparative analysis between the experimental Ouroboros language and Apple's Swift 6.2. The focus is on two key areas so far: syntax expressiveness and type system semantics. Future revisions may expand to concurrency, tooling, and ecosystem considerations.
+
+## 1. Syntax Expressiveness and Readability
+
+Ouroboros embraces a three-tiered syntax model:
+
+* **@high** – quasi-natural language constructs (e.g. `if version is greater than 1.5 then ... end if`) to lower the barrier for newcomers and domain specialists.
+* **@medium** – modern multi-paradigm idioms inspired by C#, Kotlin, Scala and Swift; includes features like `**` exponentiation, `?.` null-propagation, and concise pattern deconstruction.
+* **@low** – deterministic systems-level constructs in the spirit of C and Rust for manual memory control, pointer arithmetic and inline assembly.
+
+The language supports Unicode operators such as `∇` and `×`, and allows recursive string interpolation across these layers. Developers can switch modes to blend end-user scripting with high-performance systems code.
+
+Swift maintains a single deterministic grammar but includes features such as exhaustive `switch` statements, custom operators and an extensible string interpolation protocol. Its syntax is engineered for tooling and static analysis.
+
+**Synthesis.** Ouroboros’ natural language tier promotes accessibility though at the cost of parser determinism. Swift demonstrates that expressiveness and strong tooling can coexist. Future Ouroboros work might formalise its high level grammar and integrate guard/defer constructs for safer flow control.
+
+## 2. Type System Expressivity, Safety, and Semantic Richness
+
+Ouroboros provides deep type inference with domain‑specific units, enabling compile-time dimensional analysis. Trait-bound generics resemble Rust’s system, and the language offers discriminated unions with layout metadata for exhaustive pattern matching. Debug builds include runtime safety checks for bounds and pointer provenance.
+
+Swift centres around protocol-oriented programming with features like associated types and conditional conformances. Its optional type enforces explicit handling of `nil` and ARC manages memory automatically. Property wrappers allow declarative enforcement of field invariants.
+
+**Synthesis.** Ouroboros’ unit-aware types are ideal for scientific and mission-critical software, while Swift presents a mature protocol-driven ecosystem. Borrowing ideas like property wrappers and hybrid ownership models could enhance Ouroboros without sacrificing its low-level control.
+


### PR DESCRIPTION
## Summary
- add a new Markdown document that compares Ouroboros with Swift 6.2
- outline differences in syntax layers and type system capabilities

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_685fd802aea4833197050011d2432ce2