### PR TITLE
Add clang-format config and format target

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+SortIncludes: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,13 @@ enable_testing()
 
 add_subdirectory(src)
 add_subdirectory(tests)
+
+file(GLOB_RECURSE FORMAT_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/*.cc
+    ${CMAKE_SOURCE_DIR}/include/*.h
+    ${CMAKE_SOURCE_DIR}/tests/*.cc)
+
+add_custom_target(format
+    COMMAND clang-format -i ${FORMAT_SOURCES}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Format all source files")

--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -6,7 +6,7 @@ build system.  Please keep patches small and ensure `ctest` passes.
 Steps for new contributors:
 
 1. Fork the repository and create a feature branch.
-2. Run `clang-format` on any C++ changes.
+2. Run `clang-format` (version 14 or later) on any C++ changes.
 3. Add unit tests for new behaviour where possible.
 4. Open a pull request describing the motivation for the change.
 


### PR DESCRIPTION
## Summary
- add standard project `.clang-format`
- require clang-format 14+ in contributor guide
- add `format` helper target to CMake build

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6862a4f30d288331ad8968120fe50513