### PR TITLE
Add primitive Types section

### DIFF
--- a/OuroLang_Spec_2_0.md
+++ b/OuroLang_Spec_2_0.md
@@ -43,3 +43,28 @@ simple round‑robin executor implemented in `ouro_lang.cc`.
 Code inside a `gpu { ... }` block is earmarked for offload to a GPU
 backend.  In the current interpreter this merely prints a message but
 serves as a placeholder for future acceleration support.
+
+## Types
+
+Primitive types are inspired by common C-family languages:
+
+* `int` – 64-bit signed integer
+* `float` – 64-bit floating point number
+* `bool` – logical true or false
+* `string` – UTF‑8 encoded sequence of characters
+* `char` – single Unicode scalar value
+
+Values can be annotated with these types directly. Example tokens and control flow:
+
+```ouro
+let threshold: int = 10
+var value: int = 5
+
+if value < threshold {
+    print("below")
+} else {
+    print("above")
+}
+```
+
+Type annotations are optional when the compiler can infer them.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ zig build mod-test
 
 Detailed design notes live in the `docs/` directory. The evolving language
 specification is provided in `OuroLang_Spec_2_0.md` and outlines syntax,
-semantics and concurrency features currently implemented. Community
-contributions are welcome—see `docs/contrib.md` for guidelines.
+semantics and concurrency features currently implemented. The specification now
+includes a **Types** section describing primitive datatypes and short examples
+of control flow. Community contributions are welcome—see `docs/contrib.md` for
+guidelines.
 
 ## Fuzzing Tools
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,3 +11,5 @@ components.  The current prototype focuses on:
 
 Future iterations will replace the experimental pieces with a modular
 pipeline written in modern C++23 with optional Zig build integration.
+For details on the basic datatypes available, refer to the **Types**
+section of `../OuroLang_Spec_2_0.md`.


### PR DESCRIPTION
## Summary
- document new primitive types and example control flow in `OuroLang_Spec_2_0.md`
- reference the new section from the README and architecture docs

## Testing
- `cmake ..`
- `cmake --build . -- -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_686a8389e60c833192673a59ccf59414