### PR TITLE
Update CI to run Zig builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
       - run: |
           sudo apt-get update && sudo apt-get install -y clang-format
           find src include tests -iname '*.cc' | xargs clang-format --dry-run --Werror
+      - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.14.1
+      - run: zig fmt --check $(git ls-files '*.zig')
 
   static-analysis:
     runs-on: ubuntu-latest
@@ -24,16 +28,13 @@ jobs:
 
   build-test:
     runs-on: ubuntu-latest
-    services:
-      docker:
-        image: my_compiler/ci:latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          mkdir build && cd build
-          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain.cmake ..
-          cmake --build . -- -j$(nproc)
-          ctest --output-on-failure
+      - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.14.1
+      - run: zig build
+      - run: zig build mod-test
 
   zig-mod-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run `zig fmt --check` alongside clang-format
- use `zig build` and `zig build mod-test`
- install Zig 0.14.1 via setup-zig
- remove old CMake build steps and docker service

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y zig` *(fails: package not found)*
- `zig fmt --check $(git ls-files '*.zig')` *(fails: command not found)*
- `find src include tests -iname '*.cc' | xargs clang-format --dry-run -Werror` *(fails: code not clang-formatted)*
- `zig build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a838ae3708331ad31c00e73634be1